### PR TITLE
Add example use of the error summary helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "puma", "~> 5.2"
 gem "webpacker"
 
 # GOV.UK Formbuilder
-gem "govuk_design_system_formbuilder", ">= 2.5.0"
+gem "govuk_design_system_formbuilder", github: "dfe-digital/govuk_design_system_formbuilder", branch: "helpers"
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/dfe-digital/govuk_design_system_formbuilder.git
+  revision: 13de25b8f9adf28f9982bf5df1a5c864dd81bf19
+  branch: helpers
+  specs:
+    govuk_design_system_formbuilder (2.5.3)
+      actionview (>= 6.0)
+      activemodel (>= 6.0)
+      activesupport (>= 6.0)
+      deep_merge (~> 1.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -93,11 +104,6 @@ GEM
     foreman (0.87.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_design_system_formbuilder (2.5.0)
-      actionview (>= 6.0)
-      activemodel (>= 6.0)
-      activesupport (>= 6.0)
-      deep_merge (~> 1.2.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     listen (3.5.1)
@@ -273,7 +279,7 @@ DEPENDENCIES
   capybara (~> 3.35)
   dotenv-rails
   foreman
-  govuk_design_system_formbuilder (>= 2.5.0)
+  govuk_design_system_formbuilder!
   listen (>= 3.0.5, < 3.6)
   pry-byebug
   puma (~> 5.2)

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -17,6 +17,7 @@ class OrdersController < ApplicationController
   # GET /orders/new
   def new
     @order = Order.new
+    @order.valid?
   end
 
   # GET /orders/1/edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  include GOVUKDesignSystemFormBuilder::BuilderHelper
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,2 +1,3 @@
 class Order < ApplicationRecord
+  validates :cheese, presence: { message: "Choose a cheese please" }
 end

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -1,6 +1,6 @@
-<%= form_with(model: order) do |form| %>
-  <%= form.govuk_error_summary %>
+<%= govuk_error_summary(@order, :order) %>
 
+<%= form_with(model: order) do |form| %>
   <%= form.govuk_radio_buttons_fieldset(:size, legend: { size: "l" }) do %>
     <% @sizes.each.with_index do |(description, diameter), i| %>
       <%= form.govuk_radio_button(


### PR DESCRIPTION
This is just a demo showing off the steps required to display a error summary outside a form.

![Screenshot from 2021-06-05 14-34-50](https://user-images.githubusercontent.com/128088/120893437-3faa5700-c60b-11eb-95e6-bc2b168b18bb.png)

